### PR TITLE
Update rules.toml

### DIFF
--- a/traefik/rules.toml
+++ b/traefik/rules.toml
@@ -13,6 +13,11 @@
       [backends.unifi.servers.server-unifi-ext]
         url = "https://192.168.1.200:8443"
 
+## Allows connection to a second docker host
+  [backends.traefikdev]
+    [backends.traefikdev.servers]
+      [backends.traefikdev.servers.server-traefikdev-ext]
+url = "https://192.168.1.200:443"
 
 [frontends]
   [frontends.pihole]


### PR DESCRIPTION
adds capability for a secondary host to have full access to certs and domains.

Backend only, no frontend is needed.